### PR TITLE
Adding report parameters to puppet::server.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,6 +14,8 @@ class puppet::server (
     $dns_alt_names   = undef,
     $ca_master       = true,
     $ssldir          = undef,
+    $report          = undef,
+    $reports         = 'store,log',
 ) inherits puppet {
 
     # If we enable passenger mode, we must stop puppetmaster service

--- a/templates/master.erb
+++ b/templates/master.erb
@@ -1,5 +1,6 @@
 [master]
-    reports = store,log
+<% if @report %>    report = <%= @report %><% end %>
+<% if @reports %>    reports = <%= @reports %><% end %>
 <% if @passenger %>
     # Passenger settings
     always_cache_features = true


### PR DESCRIPTION
Some users may want to disable report or tune reports to save some space in reportdir.